### PR TITLE
Fix OSM reference

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -149,7 +149,7 @@ doi = {10.1080/15230406.2013.777138}
 
 @misc{ OSM:2017,
  author = {{OpenStreetMap contributors}},
- title = {{Planet dump retrieved from https://planet.osm.org }},
- howpublished = "\url{ https://www.openstreetmap.org }",
+ title = {Planet dump retrieved from https://planet.osm.org },
+ url = {https://www.openstreetmap.org},
  year = {2017},
 }


### PR DESCRIPTION
For some reason JOSS doesn't like the citation of OSM: 

https://wiki.openstreetmap.org/wiki/Researcher_Information#Bibtex

I have slighty modified it, so now the action and [Whedon](https://whedon.theoj.org/) compiles the paper. I think the basic information has not been altered.

Regards